### PR TITLE
fix(ReportStatus): change enum values from strings to integers

### DIFF
--- a/app/Enums/ReportStatus.php
+++ b/app/Enums/ReportStatus.php
@@ -4,10 +4,10 @@ namespace App\Enums;
 
 use Filament\Support\Contracts\HasLabel;
 
-enum ReportStatus: string implements HasLabel
+enum ReportStatus: int implements HasLabel
 {
-    case DRAFT = 'false';
-    case SUBMITTED = 'true';
+    case DRAFT = 0;
+    case SUBMITTED = 1;
 
     public function getLabel(): string
     {

--- a/app/Filament/Resources/Finance/ReportResource.php
+++ b/app/Filament/Resources/Finance/ReportResource.php
@@ -57,11 +57,11 @@ class ReportResource extends Resource
                     ->label('Status')
                     ->getStateUsing(function (Report $record): string {
                         return ReportStatus::from(
-                            $record->is_done ? 'true' : 'false'
+                            $record->is_done ? 1 : 0
                         )->getLabel();
                     })
                     ->badge()
-                    ->color(fn (Report $record): string => match (ReportStatus::from($record->is_done ? 'true' : 'false')) {
+                    ->color(fn (Report $record): string => match (ReportStatus::from($record->is_done ? 1 : 0)) {
                         ReportStatus::DRAFT => 'warning',
                         ReportStatus::SUBMITTED => 'success',
                         default => 'gray',


### PR DESCRIPTION
- Updated ReportStatus enum to use integer values for DRAFT and SUBMITTED cases.
- Modified ReportResource to reflect changes in status handling, using integers instead of strings for state and color determination.